### PR TITLE
Installing zip to docker jenkins image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ USER root
 
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y sudo && \
+    apt-get install -y sudo zip && \
     rm -rf /var/lib/apt/lists/*
 
 RUN echo "jenkins ALL=NOPASSWD: ALL" >> /etc/sudoers


### PR DESCRIPTION
Required as a dependency for the AFTC Jenkins setup as zip is required for installing sdkman on the Jenkins box which we use for managing build tools.